### PR TITLE
Revert "Merge pull request #11 from paulyoong/nexus-info-location"

### DIFF
--- a/protobuf/mayastor.proto
+++ b/protobuf/mayastor.proto
@@ -247,7 +247,6 @@ message CreateNexusV2Request {
   uint64 resvKey = 6;    // NVMe reservation key for children
   uint64 preemptKey = 7; // NVMe preempt key for children
   repeated string children = 8; // uris to the targets we connect to
-  string nexusInfoKey = 9; // the key to use to persist the nexus info structure
 }
 
 // State of the nexus child.


### PR DESCRIPTION
This reverts commit 57c97b619ce322a76bd6d9f5c4e08ea4d6a99da1, reversing
changes made to c61482c2202b2a77437ab08b60e744a19c8a2fcb.

Reverting this change because it breaks the PRs for the control plane and data 
plane because we always pull in the latest version of mayastor-api.