### PR TITLE
fix(nexus): added missing reexport for shutdown nexus request

### DIFF
--- a/src/v1.rs
+++ b/src/v1.rs
@@ -72,7 +72,7 @@ pub mod nexus {
         RebuildStateResponse, RebuildStatsRequest, RebuildStatsResponse, RemoveChildNexusRequest,
         RemoveChildNexusResponse, RemoveInjectedNexusFaultRequest, ResumeRebuildRequest,
         ResumeRebuildResponse, SetNvmeAnaStateRequest, SetNvmeAnaStateResponse,
-        StartRebuildRequest, StartRebuildResponse, StopRebuildRequest, StopRebuildResponse,
-        UnpublishNexusRequest, UnpublishNexusResponse,
+        ShutdownNexusRequest, StartRebuildRequest, StartRebuildResponse, StopRebuildRequest,
+        StopRebuildResponse, UnpublishNexusRequest, UnpublishNexusResponse,
     };
 }


### PR DESCRIPTION
Added public reexport for ShutdownNexusRequest.

Signed-off-by: Mikhail Tcymbaliuk <mtzaurus@gmail.com>