### PR TITLE
chore: revert commits that should not be in the release

### DIFF
--- a/protobuf/mayastor.proto
+++ b/protobuf/mayastor.proto
@@ -49,7 +49,6 @@ service Mayastor {
   rpc AddChildNexus (AddChildNexusRequest) returns (Child) {}
   rpc RemoveChildNexus (RemoveChildNexusRequest) returns (Null) {}
   rpc FaultNexusChild (FaultNexusChildRequest) returns (Null) {}
-  rpc ShutdownNexus (ShutdownNexusRequest) returns (Null) {}
 
   // Nexus-level fault injection and other development methods
   rpc InjectNexusFault (InjectNexusFaultRequest) returns (Null) {}
@@ -294,7 +293,6 @@ enum NexusState {
   NEXUS_ONLINE = 1;    // healthy and working
   NEXUS_DEGRADED = 2;  // not healthy but is able to serve IO (i.e. rebuild is in progress)
   NEXUS_FAULTED = 3;   // broken and unable to serve IO
-  NEXUS_SHUTDOWN = 4;  // shutdown: not able to serve I/O
 }
 
 // represents a nexus device
@@ -332,10 +330,6 @@ message ListNexusV2Reply {
 }
 
 message DestroyNexusRequest   {
-  string uuid = 1;    // uuid of the nexus
-}
-
-message ShutdownNexusRequest   {
   string uuid = 1;    // uuid of the nexus
 }
 

--- a/protobuf/v1/nexus.proto
+++ b/protobuf/v1/nexus.proto
@@ -18,7 +18,6 @@ service NexusRpc {
   rpc AddChildNexus (AddChildNexusRequest) returns (AddChildNexusResponse) {}
   rpc RemoveChildNexus (RemoveChildNexusRequest) returns (RemoveChildNexusResponse) {}
   rpc FaultNexusChild (FaultNexusChildRequest) returns (google.protobuf.Empty) {}
-  rpc ShutdownNexus (ShutdownNexusRequest) returns (google.protobuf.Empty) {}
 
   // Nexus-level fault injection and other development methods
   rpc InjectNexusFault (InjectNexusFaultRequest) returns (google.protobuf.Empty) {}
@@ -97,7 +96,6 @@ enum NexusState {
   NEXUS_ONLINE = 1;    // healthy and working
   NEXUS_DEGRADED = 2;  // not healthy but is able to serve IO (i.e. rebuild is in progress)
   NEXUS_FAULTED = 3;   // broken and unable to serve IO
-  NEXUS_SHUTDOWN = 4;  // shutdown: not able to serve I/O
 }
 
 enum NvmeAnaState {
@@ -148,10 +146,6 @@ message ListNexusResponse {
 }
 
 message DestroyNexusRequest   {
-  string uuid = 1;    // uuid of the nexus
-}
-
-message ShutdownNexusRequest   {
   string uuid = 1;    // uuid of the nexus
 }
 

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -72,7 +72,7 @@ pub mod nexus {
         RebuildStateResponse, RebuildStatsRequest, RebuildStatsResponse, RemoveChildNexusRequest,
         RemoveChildNexusResponse, RemoveInjectedNexusFaultRequest, ResumeRebuildRequest,
         ResumeRebuildResponse, SetNvmeAnaStateRequest, SetNvmeAnaStateResponse,
-        ShutdownNexusRequest, StartRebuildRequest, StartRebuildResponse, StopRebuildRequest,
-        StopRebuildResponse, UnpublishNexusRequest, UnpublishNexusResponse,
+        StartRebuildRequest, StartRebuildResponse, StopRebuildRequest, StopRebuildResponse,
+        UnpublishNexusRequest, UnpublishNexusResponse,
     };
 }


### PR DESCRIPTION
chore: revert "Merge pull request #29 from mtzaurus/nexus_shutdown_api"

This reverts commit https://github.com/openebs/mayastor-api/commit/7965ed34cf814a19525b0c90c04ca5ca20a1b6c0, reversing
changes made to https://github.com/openebs/mayastor-api/commit/ed76106411210f289b240ec083c5acb7b9e9123c.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>

---

chore: revert "Merge pull request #30 from mtzaurus/shutdown_nexus_request"

This reverts commit https://github.com/openebs/mayastor-api/commit/ed76106411210f289b240ec083c5acb7b9e9123c, reversing
changes made to https://github.com/openebs/mayastor-api/commit/faf035bc701bdf53c6eeb26b9844ed9be2a6e92a.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>