### PR TITLE
fix: add allowed-hosts to forgotten api 0 nexus v2

### DIFF
--- a/protobuf/mayastor.proto
+++ b/protobuf/mayastor.proto
@@ -361,6 +361,7 @@ message NexusV2 {
   string device_uri = 6;
   uint32 rebuilds = 7;         // total number of rebuild tasks
   NvmeAnaState ana_state = 8;  // Nexus ANA state.
+  repeated string allowed_hosts = 9; // host (nqn's) which are allowed to connect to the target
 }
 
 message ListNexusV2Reply {


### PR DESCRIPTION
Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>