### PR TITLE
chore: export new types added for rebuild history

### DIFF
--- a/src/v1.rs
+++ b/src/v1.rs
@@ -73,6 +73,7 @@ pub mod nexus {
         ListInjectedNexusFaultsReply, ListInjectedNexusFaultsRequest, ListNexusOptions,
         ListNexusResponse, Nexus, NexusNvmePreemption, NexusState, NvmeAnaState, NvmeReservation,
         PauseRebuildRequest, PauseRebuildResponse, PublishNexusRequest, PublishNexusResponse,
+        RebuildHistoryRecord, RebuildHistoryRequest, RebuildHistoryResponse, RebuildJobState,
         RebuildStateRequest, RebuildStateResponse, RebuildStatsRequest, RebuildStatsResponse,
         RemoveChildNexusRequest, RemoveChildNexusResponse, RemoveInjectedNexusFaultRequest,
         ResumeRebuildRequest, ResumeRebuildResponse, SetNvmeAnaStateRequest,


### PR DESCRIPTION
export the new grpc v1 message types added for rebuild history. Should
have been ideally done along with protobuf changes but was apparently missed.

Signed-off-by: Diwakar Sharma <diwakar.sharma@datacore.com>