### PR TITLE
chore(nexus_child/fault): add fault timestamp for nexus child

### DIFF
--- a/protobuf/v1/nexus.proto
+++ b/protobuf/v1/nexus.proto
@@ -112,6 +112,7 @@ message Child {
   ChildStateReason state_reason = 3;  // child state reason
   int32 rebuild_progress = 4;         // rebuild progress
   optional string device_name = 5;    // child device name
+  google.protobuf.Timestamp fault_timestamp = 6;   // timestamp(UTC) when child went faulted
 }
 
 // State of the nexus (terminology inspired by ZFS).


### PR DESCRIPTION
Adds a timestamp when the child goes to faulted state. If child has never faulted, this will be blank.