### PR TITLE
fix(replica): add pool name/uuid for replica destroy

### DIFF
--- a/protobuf/v1/replica.proto
+++ b/protobuf/v1/replica.proto
@@ -52,7 +52,11 @@ message CreateReplicaRequest {
 
 // Destroy replica arguments.
 message DestroyReplicaRequest {
-  string uuid = 1;  // uuid of the replica
+  string uuid = 1;  // uuid of the replica.
+  oneof pool {
+    string pool_name = 2; // name of the pool where the replica resides.
+    string pool_uuid = 3; // optional uuid for the pool where the replica resides.
+  }
 }
 
 // Share replica request.
@@ -75,6 +79,7 @@ message ListReplicasResponse {
 
 message ListReplicaOptions {
   google.protobuf.StringValue name = 1; // list the replica with the name if provided
-  google.protobuf.StringValue poolname = 2; // list the replicas on the provided pool
+  google.protobuf.StringValue poolname = 2; // list the replicas on the provided pool, by name
   google.protobuf.StringValue uuid = 3; // list the replica with the uuid if provided
+  google.protobuf.StringValue pooluuid = 4; // list the replicas on the provided pool, by uuid
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -41,6 +41,7 @@ pub mod pool {
 
 pub mod replica {
     pub use super::pb::{
+        destroy_replica_request,
         replica_rpc_client::ReplicaRpcClient,
         replica_rpc_server::{ReplicaRpc, ReplicaRpcServer},
         CreateReplicaRequest, DestroyReplicaRequest, ListReplicaOptions, ListReplicasResponse,


### PR DESCRIPTION
This would allow the data-plane to determine whether a pool is loaded or not. Example: if a pool is not loaded then we cannot destroy the replica and we must return an adequate error code back as it's the control-plane job to import pools before attempting to destroy replicas.